### PR TITLE
Fix version missmatch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '0.4.16'
+    id 'org.jetbrains.intellij' version '0.4.26'
 }
 
 group 'org.cosee'
@@ -24,7 +24,7 @@ test {
 }
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version '2019.3'
+    version '2020.2'
     type 'CL'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ intellij {
 }
 
 patchPluginXml {
+    untilBuild '' // remove until-build from XML
     changeNotes """
       First release"""
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,15 @@
+// workaround for https://github.com/JetBrains/gradle-intellij-plugin/issues/537
+pluginManagement {
+    repositories {
+        maven {
+            url 'https://jetbrains.bintray.com/intellij-plugin-service'
+        }
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'itm_viewer'
 


### PR DESCRIPTION
Hallo Mohamad,

thank you very much for this great plugin.

I have updated the intellij dependency to `0.4.26` and bumped up the version to `2020.2`. I have also removed `until-build` from the generated XML, this way the plugin does not need to be updated in order to be installed on the next major version of CLion.